### PR TITLE
cleanup contents of batch downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-Scripts for use with the Digital Library of India (DLI) website. 
+Scripts for use with the Digital Library of India (DLI) website.
 [https://sites.google.com/site/sanskritcode/]. Contributions welcome!
 
-Vishvas likes the Bash tool best.
+The Python tool (mirrored from [here](https://raw.githubusercontent.com/aupasana/aupasana/master/OSXScripts/dli.py) for convenience) is most feature-rich and up-to-date. This tool searches the Digital Library of India for books by barcode (on multiple mirrors), downloads the TIFF files from the best server, and then converts and combines them into a single PDF.
 
-dli downloader (mac osx / linux)
+Dependencies: libtiff
+Recommends: aria2
 
-# Other tools #
-## Aupasana tool ##
-Script: [https://raw.githubusercontent.com/aupasana/aupasana/master/OSXScripts/dli.py] dli.py - a python script to search for Digital Library of India books by barcode (on multiple mirrors), download the tiff files from a specific server, and then convert and combine them into a single pdf. Details here [http://www.aupasana.com/software#TOC-dli-downloader-mac-osx-linux-] We keep of a copy here for convenience.
+For more details: see [http://aupasana.com/pages/software.html#dli-downloader]

--- a/py/dli-multi.sh
+++ b/py/dli-multi.sh
@@ -2,21 +2,20 @@
 
 # dli-multi
 # =================
-# A convenience wrapper to the dli-avaropa script for batch processing a list of books to download. Based on a similar scipt by shrIramaNa.
+# A convenience wrapper to the dli script for batch processing a list of books to download.
 #
 # USAGE: dli-multi <filename>
 #        <filename> - file in which each line contains (only) a DLI barcode and local ad-hoc book name separated by whitespace
-# set -o verbose
 
-[ "$#" != "1" ] && echo "USAGE: dli-multi.sh <filename>" >&2 && exit 1
+[ "$#" != "1" ] && echo "USAGE: dli-multi <filename>" >&2 && exit 1
 
 cat "$1" | while read barcode bookname
 do
 	echo $barcode $bookname
 	if [ -z "$barcode" -o -z "$bookname" ] ; then
-		echo "dli-avaropa-multi.sh ERROR: malformed input line: $barcode $bookname"
+		echo "ERROR: malformed input line: $barcode $bookname"
 		continue
 	fi
 	pdffilename=$(echo $bookname|tr " " "_")
-	~/DLI-tools/py/dli.py "$barcode" --pdf-name="\"$pdffilename\""
+	dli "$barcode" --pdf-name="$pdffilename"
 done


### PR DESCRIPTION
don't refer to dli by absolute path
assumes scripts exist on current search path without extension
change underscore to hyphen in filename of batch downloader, easier to type and more Unix-ish
cleanup readme to explicitly recommend Python tool and not out-of-date Bash tool
